### PR TITLE
Add Twitter follow link to raffle page

### DIFF
--- a/content/raffle/index.md
+++ b/content/raffle/index.md
@@ -7,7 +7,11 @@ date: 2019-05-09T15:28:25+01:00
 
 Enter the London Gophers [JetBrains](https://www.jetbrains.com) raffle!
 
-At each meetup we will announce a special key. Simply enter that along with your Twitter handle below and tweet us
+First things first, follow us on Twitter:
+
+<a href="https://twitter.com/LondonGophers?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-show-count="false">Follow @LondonGophers</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+
+Then, at each meetup we will announce a special key. Simply enter that below along with your Twitter handle and tweet us
 before the end of the meetup to be entered into the draw!
 
 <iframe src="https://londongophers.github.io/raffle/?greeting=Hey%20%40LondonGophers%2C%20please%20enter%20me%20into%20the%20%40jetbrains%20raffle!&amp;hashtags=LondonGophers" style="border:0px;width:100%;overflow:hidden"></iframe>

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -27,7 +27,9 @@
       
       <guid>https://gophers.london/raffle/</guid>
       <description>JetBrains Raffle! Enter the London Gophers JetBrains raffle!
-At each meetup we will announce a special key. Simply enter that along with your Twitter handle below and tweet us before the end of the meetup to be entered into the draw!</description>
+First things first, follow us on Twitter:
+Follow @LondonGophers
+Then, at each meetup we will announce a special key. Simply enter that below along with your Twitter handle and tweet us before the end of the meetup to be entered into the draw!</description>
     </item>
     
     <item>

--- a/docs/raffle/index.html
+++ b/docs/raffle/index.html
@@ -52,7 +52,11 @@
 
 <p>Enter the London Gophers <a href="https://www.jetbrains.com">JetBrains</a> raffle!</p>
 
-<p>At each meetup we will announce a special key. Simply enter that along with your Twitter handle below and tweet us
+<p>First things first, follow us on Twitter:</p>
+
+<p><a href="https://twitter.com/LondonGophers?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-show-count="false">Follow @LondonGophers</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script></p>
+
+<p>Then, at each meetup we will announce a special key. Simply enter that below along with your Twitter handle and tweet us
 before the end of the meetup to be entered into the draw!</p>
 
 <iframe src="https://londongophers.github.io/raffle/?greeting=Hey%20%40LondonGophers%2C%20please%20enter%20me%20into%20the%20%40jetbrains%20raffle!&amp;hashtags=LondonGophers" style="border:0px;width:100%;overflow:hidden"></iframe>


### PR DESCRIPTION
In order to be able to DM some people, they need to have followed us (a
certain privacy setting I believe). Hence we should make sure people
actually follow us as step 1